### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,8 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 JQ_SOURCE_DIR="$BUILD_DIR/.heroku/vendor/jq" # where the jq source code will be
 JQ_BUILD_DIR="$BUILD_DIR/vendor/jq" # where the jq binaries will be stored (in subdirectories) during buildpack execution
-JQ_HOME_DIR="$HOME/vendor/jq" # where the jq binaries will be stored (in subdirectories) during dyno execution
+ # Single quotes since we want $HOME to be resolved at runtime, not build time.
+JQ_HOME_DIR='$HOME/vendor/jq' # where the jq binaries will be stored (in subdirectories) during dyno execution
 JQ_CACHE_DIR="$CACHE_DIR/vendor/jq" # where the jq binaries will be cached (in subdirectories)
 PROFILE_DIR="$BUILD_DIR/.profile.d"
 PROFILE_PATH="$PROFILE_DIR/jq.sh"


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or so we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack was found to not be compatible with this change, which will be fixed by this PR.

---

Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`.

By using single quotes, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.